### PR TITLE
Add ansible-lint into example repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 ansible-core==2.16.3
 iac-test==0.2.5
 iac-validate==0.2.3
+ansible-lint
 macaddress
 requests


### PR DESCRIPTION
We should include ansible-lint in the example repo such that it instills best practices.