### PR TITLE
Remove dev reference. Leave for dev doc

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -12,6 +12,3 @@ collections:
     version: 5.3.0
   - name: cisco.dcnm
     version: 3.5.0
-  # - name: https://github.com/netascode/ansible-dc-vxlan.git   # uncomment this item upon release
-  #   type: git
-  #   version: develop   # change version later


### PR DESCRIPTION
Remove reference to git repo in the public example. Leave explanation for dev doc and those elements. 