### PR TITLE
Add login domain httpapi param

### DIFF
--- a/group_vars/ndfc/connection.yaml
+++ b/group_vars/ndfc/connection.yaml
@@ -3,10 +3,11 @@
 #
 # Controller Credentials
 ansible_connection: ansible.netcommon.httpapi
+ansible_network_os: cisco.dcnm.dcnm
 ansible_httpapi_port: 443
 ansible_httpapi_use_ssl: true
 ansible_httpapi_validate_certs: false
-ansible_network_os: cisco.dcnm.dcnm
+ansible_httpapi_login_domain: local
 # NDFC API Credentials
 ansible_user: "{{ lookup('env', 'ND_USERNAME') }}"
 ansible_password: "{{ lookup('env', 'ND_PASSWORD') }}"

--- a/group_vars/ndfc/connection.yaml
+++ b/group_vars/ndfc/connection.yaml
@@ -7,7 +7,7 @@ ansible_network_os: cisco.dcnm.dcnm
 ansible_httpapi_port: 443
 ansible_httpapi_use_ssl: true
 ansible_httpapi_validate_certs: false
-ansible_httpapi_login_domain: local
+ansible_httpapi_login_domain: "{{ lookup('env', 'ND_DOMAIN') }}"
 # NDFC API Credentials
 ansible_user: "{{ lookup('env', 'ND_USERNAME') }}"
 ansible_password: "{{ lookup('env', 'ND_PASSWORD') }}"


### PR DESCRIPTION
Adding param to connection.yaml in prep for support in collection to support different domains for current and future versions of NDFC.