### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ ansible-lint
 iac-validate==0.2.5
 iac-test==0.2.5
 macaddress
+netaddr
 packaging==24.1
 requests


### PR DESCRIPTION
To use ipaddr filter in Ansible, you need to install the netaddr Python library.  Required for prep_107_vrf_lites.py https://docs.ansible.com/ansible/latest/collections/ansible/utils/docsite/filters_ipaddr.html