### PR TITLE
Fixing typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ The validate role will automatically run if tags `role_create, role_deploy, role
 Example: Selectively Run `cisco.nac_dc_vxlan.create` role alone
 
 ```bash
-ansible-playbook -i inventory.yml vxlan.yml --tags role_create
+ansible-playbook -i inventory.yaml vxlan.yaml --tags role_create
 ```
 
 ## Service Model Data


### PR DESCRIPTION
Changing "yml" to "yaml" on the playbook examples.