### PR TITLE
Fixed layer2_host_interfacde_mtu typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,15 +216,17 @@ The `remove` role removes state from the NDFC controller and the devices managed
 Inside the example repository under `group_vars/ndfc` is a file called `ndfc.yaml` that contains the variables:
 
 ```yaml
-# Control Parameters for 'Remove' role tasks
+# Parameters for the tasks in the 'Remove' role
 interface_delete_mode: false
 inventory_delete_mode: false
-link_fabric_delete_mode: false
 link_vpc_delete_mode: false
+multisite_child_fabric_delete_mode: false
+multisite_network_delete_mode: false
+multisite_vrf_delete_mode: false
 network_delete_mode: false
 policy_delete_mode: false
-vpc_delete_mode: false
 vrf_delete_mode: false
+vpc_delete_mode: false
 ```
 
 **Note:** These variables are set to `false` by default to avoid accidental removal of configuration from NDFC that might impact the network. 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 250
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true
     ipv4:
       underlay_routing_loopback_ip_range: 10.0.0.0/22

--- a/host_vars/nac-fabric1/underlay.nac.yaml
+++ b/host_vars/nac-fabric1/underlay.nac.yaml
@@ -12,7 +12,7 @@ vxlan:
       underlay_routing_protocol_tag: UNDERLAY
       underlay_rp_loopback_id: 250
       intra_fabric_interface_mtu: 9216
-      layer2_host_interfacde_mtu: 9216
+      layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true
     ipv4:
       underlay_routing_loopback_ip_range: 10.0.0.0/22


### PR DESCRIPTION
Fixed layer2_host_interfacde_mtu typo in the following files. 

README.md
host_vars/nac-fabric1/underlay.nac.yaml