### PR TITLE
Fix for issue #41

### DIFF
--- a/host_vars/nac-fabric1/underlay.nac.yaml
+++ b/host_vars/nac-fabric1/underlay.nac.yaml
@@ -5,8 +5,6 @@ vxlan:
       routing_protocol: ospf
       enable_ipv6_underlay: false
       replication_mode: multicast
-      fabric_interface_numbering: p2p
-      subnet_mask: 31
       underlay_routing_loopback_id: 0
       underlay_vtep_loopback_id: 1
       underlay_routing_protocol_tag: UNDERLAY
@@ -15,6 +13,8 @@ vxlan:
       layer2_host_interface_mtu: 9216
       unshut_host_interfaces: true
     ipv4:
+      fabric_interface_numbering: p2p
+      subnet_mask: 31
       underlay_routing_loopback_ip_range: 10.0.0.0/22
       underlay_vtep_loopback_ip_range: 10.100.100.0/22
       underlay_rp_loopback_ip_range: 10.250.250.0/24


### PR DESCRIPTION
Fixes issue #41 

The `fabric_interface_numbering` and `subnet_mask` keys are moved from `vxlan.underlay.general` to `vxlan.underlay.ipv4`.

Files using the keys:

- nac-ndfc/collections/ansible_collections/cisco/nac_dc_vxlan/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/general/dc_vxlan_fabric_general.j2
- nac-ndfc/collections/ansible_collections/cisco/nac_dc_vxlan/roles/dtc/common/templates/ndfc_fabric/dc_vxlan_fabric/protocols/dc_vxlan_fabric_protocols.j2

Schema (nac-vxlan/schemas/schema.yaml):
`# underlay parameters
underlay:
  general: include('underlay_general', required=False)
  ipv4: include('underlay_ipv4', required=False)
  [..]

underlay_general:
  [..]

underlay_ipv4:
  fabric_interface_numbering: enum('p2p', 'unnumbered', required=False)
  subnet_mask: int(min=30, max=31, required=False)
  [..]
`