### PR TITLE
ND4.1: Validation of cisco.nd.rest module

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ ansible_connection: ansible.netcommon.httpapi
 ansible_httpapi_port: 443
 ansible_httpapi_use_ssl: true
 ansible_httpapi_validate_certs: false
-ansible_network_os: cisco.dcnm.dcnm
+ansible_network_os: cisco.nd.nd
 # NDFC API Credentials
 ansible_user: "{{ lookup('env', 'ND_USERNAME') }}"
 ansible_password: "{{ lookup('env', 'ND_PASSWORD') }}"

--- a/group_vars/ndfc/connection.yaml
+++ b/group_vars/ndfc/connection.yaml
@@ -3,7 +3,7 @@
 #
 # Controller Credentials
 ansible_connection: ansible.netcommon.httpapi
-ansible_network_os: cisco.dcnm.dcnm
+ansible_network_os: cisco.nd.nd
 ansible_httpapi_port: 443
 ansible_httpapi_use_ssl: true
 ansible_httpapi_validate_certs: false

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -12,3 +12,5 @@ collections:
     version: 3.8.1
   - name: cisco.nac_dc_vxlan
     version: 0.4.3
+  - name: cisco.nd
+    version: 1.3.0


### PR DESCRIPTION
Description:

The [ND Rest Module](https://github.com/CiscoDevNet/ansible-nd/blob/master/plugins/modules/nd_rest.py) needs to be validated against our [VXLAN as Code](https://github.com/netascode/ansible-dc-vxlan) collection to ensure that everywhere our [DCNM Rest Module](https://github.com/CiscoDevNet/ansible-dcnm/blob/develop/plugins/modules/dcnm_rest.py) is used we can replace it and it works.

Replace all instances of cisco.dcnm.dcnm_rest with cisco.nd.nd_rest
https://github.com/search?q=repo%3Anetascode%2Fansible-dc-vxlan+dcnm_rest&type=code&p=1
Update Ansible collection requirements to include cisco.nd
https://github.com/netascode/ansible-dc-vxlan-example/blob/main/requirements.yaml
Verify end to end workflows using the nd connection plugin
https://github.com/netascode/ansible-dc-vxlan-example/blob/main/requirements.yaml
Replace this line with ansible_network_os: cisco.nd.nd


Tested with the below playbook

hosts: nac-fabric1
any_errors_fatal: true
gather_facts: no

tasks:

name: Test simple GET request using nd_rest module
cisco.nd.nd_rest:
#path: "/api/v1/manage/fabricsSummary"
#path: "/api/v1/manage/inventory/switches"
#path: "/appcenter/cisco/ndfc/api/v1/lan-discovery/inventory/modules"
path: "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/"
method: GET
register: result