### PR TITLE
Update requirements.yaml for 0.7.2

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -9,6 +9,6 @@ collections:
   - name: ansible.netcommon
     version: 7.1.0
   - name: cisco.dcnm
-    version: 3.11.0
+    version: 3.11.1
   - name: cisco.nac_dc_vxlan
-    version: 0.7.1
+    version: 0.7.2


### PR DESCRIPTION
 Update:
  - name: cisco.dcnm
    version: 3.11.1
  - name: cisco.nac_dc_vxlan
    version: 0.7.2